### PR TITLE
Add validation for timing parameters

### DIFF
--- a/timelapse/app.py
+++ b/timelapse/app.py
@@ -23,8 +23,14 @@ capturing = False
 def index():
     global capturing
     if request.method == 'POST' and not capturing:
-        spf = float(request.form['seconds_per_frame'])
-        dur = float(request.form['duration'])
+        try:
+            spf = float(request.form['seconds_per_frame'])
+            dur = float(request.form['duration'])
+            if spf <= 0 or dur <= 0:
+                raise ValueError
+        except ValueError:
+            return redirect(url_for('index'))
+
         iso = request.form['iso']
         focus = request.form['focus']
         threading.Thread(
@@ -53,6 +59,9 @@ def download(filename):
 
 def capture(seconds_per_frame, duration, iso, focus):
     global capturing
+    if seconds_per_frame <= 0 or duration <= 0:
+        capturing = False
+        return
     ts = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
     out = os.path.join(IMG_DIR, f'tl_{ts}')
     os.makedirs(out, exist_ok=True)

--- a/timelapse/templates/index.html
+++ b/timelapse/templates/index.html
@@ -30,10 +30,10 @@
 
   <form method="post">
     <label>Sekunden/Frame:
-      <input type="number" name="seconds_per_frame" step="0.1" required>
+      <input type="number" name="seconds_per_frame" step="0.1" min="0.1" required>
     </label>
     <label>Dauer (s):
-      <input type="number" name="duration" step="1" required>
+      <input type="number" name="duration" step="1" min="1" required>
     </label>
     <label>ISO:
       <select name="iso">


### PR DESCRIPTION
## Summary
- validate `seconds_per_frame` and `duration` in Flask view
- reject invalid parameters inside `capture`
- require positive values in HTML form

## Testing
- `python3 -m py_compile timelapse/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684bc9f9a61c832b9e66dfaef4fc4153