### PR TITLE
Add one-click installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,20 @@ Dieses Repo richtet deinen Raspberry Pi Zero 2 W als WLAN-Hotspot ein, startet b
 
 ## Installation
 
-1. **System updaten & Pakete installieren**
-   ```bash
-   sudo apt update && sudo apt upgrade -y
-   sudo apt install hostapd dnsmasq python3-flask python3-opencv \
-                    libcamera-apps ffmpeg
-   pip3 install picamera2
+F\u00fcr die Schnellinstallation gibt es ein Skript, das zun\u00e4chst dieses
+Repository klont und danach `install.sh` aufruft. Es reicht also, den
+folgenden Befehl auszuf\u00fchren:
+
+```bash
+curl -sL https://raw.githubusercontent.com/USERNAME/RaspiZeroCam/main/install-oneclick.sh | bash
 ```
 
-2. **Konfigurationsdateien kopieren**
-   ```bash
-   ./install-network.sh
-   ```
+Nach Abschluss empfiehlt sich ein Neustart des Pi, damit Hotspot und Webdienst
+laufen.
+
+Wer das Repository bereits geklont hat, kann die Installation auch direkt 
+per
+
+```bash
+./install.sh
+```

--- a/install-oneclick.sh
+++ b/install-oneclick.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+REPO_URL="https://github.com/USERNAME/RaspiZeroCam.git"
+TARGET_DIR="$HOME/RaspiZeroCam"
+
+if [ ! -d "$TARGET_DIR" ]; then
+    git clone "$REPO_URL" "$TARGET_DIR"
+else
+    echo "$TARGET_DIR exists, pulling latest changes"
+    git -C "$TARGET_DIR" pull
+fi
+
+cd "$TARGET_DIR"
+./install.sh

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# Install required packages
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y hostapd dnsmasq python3-flask python3-opencv libcamera-apps ffmpeg
+sudo pip3 install picamera2
+
+# Copy network configuration files
+sudo cp network-config/dhcpcd.conf /etc/dhcpcd.conf
+sudo cp network-config/hostapd.conf /etc/hostapd/hostapd.conf
+sudo cp network-config/dnsmasq.conf /etc/dnsmasq.conf
+
+# Copy application files
+sudo mkdir -p /home/pi/timelapse
+sudo cp -r timelapse/* /home/pi/timelapse/
+
+# Install systemd service
+sudo cp systemd/timelapse.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable timelapse.service
+
+# Clean up apt caches
+sudo apt clean
+
+echo "Installation abgeschlossen. Jetzt neu starten."


### PR DESCRIPTION
## Summary
- add `install-oneclick.sh` that clones the repo and runs `install.sh`
- update README with quick install instructions

## Testing
- `bash -n install.sh`
- `bash -n install-oneclick.sh`


------
https://chatgpt.com/codex/tasks/task_e_684bcc57faac832ba91f1f7e22107a9c