### PR TITLE
Change duration input to hours:minutes

### DIFF
--- a/timelapse/app.py
+++ b/timelapse/app.py
@@ -25,10 +25,19 @@ def index():
     if request.method == 'POST' and not capturing:
         try:
             spf = float(request.form['seconds_per_frame'])
-            dur = float(request.form['duration'])
+            dur_str = request.form['duration']
+            parts = dur_str.split(':')
+            if len(parts) == 2:
+                h, m = parts
+                dur = int(h) * 3600 + int(m) * 60
+            elif len(parts) == 3:
+                h, m, s = parts
+                dur = int(h) * 3600 + int(m) * 60 + int(s)
+            else:
+                raise ValueError
             if spf <= 0 or dur <= 0:
                 raise ValueError
-        except ValueError:
+        except (ValueError, KeyError):
             return redirect(url_for('index'))
 
         iso = request.form['iso']

--- a/timelapse/templates/index.html
+++ b/timelapse/templates/index.html
@@ -32,8 +32,8 @@
     <label>Sekunden/Frame:
       <input type="number" name="seconds_per_frame" step="0.1" min="0.1" required>
     </label>
-    <label>Dauer (s):
-      <input type="number" name="duration" step="1" min="1" required>
+    <label>Dauer (hh:mm):
+      <input type="time" name="duration" step="60" required>
     </label>
     <label>ISO:
       <select name="iso">


### PR DESCRIPTION
## Summary
- change `index.html` to accept duration as hh:mm
- parse hh:mm duration in `app.py`

## Testing
- `python3 -m py_compile timelapse/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684bd0d5b1e0832b8320e18800ab840d