### PR TITLE
Add abort functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Dieses Repo richtet deinen Raspberry Pi Zero 2 W als WLAN-Hotspot ein, startet b
   - Fokus (Auto, Unendlich)
   - Live-Vorschau (MJPEG)
   - Download fertiger Videos
+  - Aufnahme kann vorzeitig abgebrochen werden
 - **libcamera-still** für Bilder
 - **FFmpeg** für FHD-Videos
 - **systemd**-Service für Autostart
@@ -52,6 +53,9 @@ per
    die Gesamtdauer sowie ISO und Fokus.
 4. Gewünschte Werte eintragen und auf **Aufnahme starten** klicken. Während
    der Aufnahme ist die Schaltfläche deaktiviert.
-5. Nach Abschluss erscheint das erzeugte Video unter *Fertige Videos* und
+5. Läuft eine Aufnahme, kann sie über **Aufnahme abbrechen** vorzeitig beendet
+   werden. Anschließend lässt sich entscheiden, ob aus den vorhandenen Bildern
+   ein Video gerendert oder alles verworfen wird.
+6. Nach Abschluss erscheint das erzeugte Video unter *Fertige Videos* und
    kann direkt heruntergeladen werden. Die Datei wird auch auf dem Pi unter
    `/home/pi/timelapse/videos` gespeichert.

--- a/timelapse/templates/cancel.html
+++ b/timelapse/templates/cancel.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <title>Aufnahme abbrechen</title>
+  <style>
+    body { font-family:sans-serif; background:#1a1a1a; color:#eee; margin:0; padding:1rem; }
+    h1 { color:#f0a500; }
+    form { display:inline-block; margin-right:1rem; }
+    button { padding:.4rem .6rem; border:none; border-radius:4px; background:#f0a500; color:#1a1a1a; cursor:pointer; font-weight:bold; }
+  </style>
+</head>
+<body>
+  <h1>Aufnahme abbrechen</h1>
+  <p>Es wurden bereits {{ images }} Bilder aufgenommen.</p>
+  <p>Wie soll fortgefahren werden?</p>
+  <form action="{{ url_for('cancel_action') }}" method="post">
+    <input type="hidden" name="action" value="render">
+    <button type="submit">Video rendern</button>
+  </form>
+  <form action="{{ url_for('cancel_action') }}" method="post">
+    <input type="hidden" name="action" value="discard">
+    <button type="submit">Komplett abbrechen</button>
+  </form>
+</body>
+</html>

--- a/timelapse/templates/index.html
+++ b/timelapse/templates/index.html
@@ -55,6 +55,12 @@
     </button>
   </form>
 
+  {% if capturing %}
+  <form action="{{ url_for('cancel') }}" method="post" style="margin-top:1rem;">
+    <button type="submit">Aufnahme abbrechen</button>
+  </form>
+  {% endif %}
+
   <h2>Fertige Videos</h2>
   <ul>
     {% raw %}{% for v in videos %}{% endraw %}


### PR DESCRIPTION
## Summary
- add cancel button to stop timelapse recording
- prompt for rendering or discarding frames when cancelled
- implement routes and helper function in `app.py`
- document the new abort feature in README

## Testing
- `python3 -m py_compile timelapse/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684bd9527a68832b916ed035644586a7