### PR TITLE
Fix service on port 80 with authbind

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ curl -sL https://raw.githubusercontent.com/philippxmeyer/RaspiZeroCam/main/insta
 ```
 
 Nach Abschluss empfiehlt sich ein Neustart des Pi, damit Hotspot und Webdienst
-laufen.
+laufen. Das Skript installiert dabei `authbind`, richtet die nötigen
+Berechtigungen ein und erlaubt so dem Flask-Server, weiterhin als Benutzer
+`pi` auf Port 80 zu lauschen.
 
 Wer das Repository bereits geklont hat, kann die Installation auch direkt
 per

--- a/install.sh
+++ b/install.sh
@@ -3,12 +3,22 @@ set -e
 
 # Install required packages
 sudo apt update && sudo apt upgrade -y
-sudo apt install -y hostapd dnsmasq python3-flask libcamera-apps ffmpeg
+sudo apt install -y hostapd dnsmasq python3-flask libcamera-apps ffmpeg authbind
 
 # Copy network configuration files
 sudo cp network-config/dhcpcd.conf /etc/dhcpcd.conf
 sudo cp network-config/hostapd.conf /etc/hostapd/hostapd.conf
 sudo cp network-config/dnsmasq.conf /etc/dnsmasq.conf
+
+# Enable hotspot services
+sudo systemctl unmask hostapd
+sudo systemctl enable hostapd
+sudo systemctl enable dnsmasq
+
+# Allow user 'pi' to bind to port 80 using authbind
+sudo touch /etc/authbind/byport/80
+sudo chown pi /etc/authbind/byport/80
+sudo chmod 500 /etc/authbind/byport/80
 
 # Copy application files
 sudo mkdir -p /home/pi/timelapse

--- a/systemd/timelapse.service
+++ b/systemd/timelapse.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=pi
 WorkingDirectory=/home/pi/timelapse
-ExecStart=/usr/bin/python3 /home/pi/timelapse/app.py
+ExecStart=/usr/bin/authbind --deep /usr/bin/python3 /home/pi/timelapse/app.py
 Restart=always
 
 [Install]


### PR DESCRIPTION
## Summary
- install authbind and configure permissions
- enable hostapd/dnsmasq and allow Flask service to listen on port 80
- update systemd service to use authbind
- document authbind setup in README

## Testing
- `bash -n install.sh`
- `bash -n install-oneclick.sh`
- `python3 -m py_compile timelapse/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684c9398aa74832b82b8da5d3ed19345