### PR TITLE
Fix timelapse duration parsing and video fps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dieses Repo richtet deinen Raspberry Pi Zero 2 W als WLAN-Hotspot ein, startet b
   - Download fertiger Videos
   - Aufnahme kann vorzeitig abgebrochen werden
 - **libcamera-still** für Bilder
-- **FFmpeg** für FHD-Videos
+ - **FFmpeg** für FHD-Videos (30 FPS)
 - **systemd**-Service für Autostart
 - Fortlaufend nummerierte Ordner und Videos
 
@@ -54,7 +54,8 @@ per
    beitreten.
 3. Im Browser `http://192.168.4.1` aufrufen. Die Weboberfläche zeigt eine
    Live-Vorschau der Kamera und Eingabefelder für das Timelapse-Intervall,
-   die Gesamtdauer sowie ISO und Fokus.
+   die Gesamtdauer sowie ISO und Fokus. Die Dauer wird im Format
+   `hh:mm:ss` angegeben.
 4. Gewünschte Werte eintragen und auf **Aufnahme starten** klicken. Während
    der Aufnahme ist die Schaltfläche deaktiviert.
 5. Läuft eine Aufnahme, kann sie über **Aufnahme abbrechen** vorzeitig beendet

--- a/timelapse/app.py
+++ b/timelapse/app.py
@@ -10,6 +10,9 @@ VID_DIR = os.path.join(BASE, 'videos')
 os.makedirs(IMG_DIR, exist_ok=True)
 os.makedirs(VID_DIR, exist_ok=True)
 
+# Wiedergabe-FPS für gerenderte Videos
+OUTPUT_FPS = 30
+
 # Einfaches Logging zur Fehlersuche
 logging.basicConfig(
     filename=os.path.join(BASE, 'timelapse.log'),
@@ -113,9 +116,12 @@ def cancel_action():
 def render_video(img_dir, fps, run_num):
     video_file = os.path.join(VID_DIR, f'{run_num}.mp4')
     subprocess.run([
-        'ffmpeg','-y','-r',str(fps),
-        '-pattern_type','glob','-i',os.path.join(img_dir,'*.jpg'),
-        '-vf','scale=1920:1080','-c:v','libx264','-pix_fmt','yuv420p',
+        'ffmpeg', '-y',
+        '-framerate', str(fps),
+        '-pattern_type', 'glob', '-i', os.path.join(img_dir, '*.jpg'),
+        '-vf', 'scale=1920:1080',
+        '-r', str(OUTPUT_FPS),
+        '-c:v', 'libx264', '-pix_fmt', 'yuv420p',
         video_file
     ], check=True)
 

--- a/timelapse/templates/index.html
+++ b/timelapse/templates/index.html
@@ -32,8 +32,8 @@
     <label>Sekunden/Frame:
       <input type="number" name="seconds_per_frame" step="0.1" min="0.1" required>
     </label>
-    <label>Dauer (hh:mm):
-      <input type="time" name="duration" step="60" required>
+    <label>Dauer (hh:mm:ss):
+      <input type="time" name="duration" step="1" required>
     </label>
     <label>ISO:
       <select name="iso">


### PR DESCRIPTION
## Summary
- allow specifying seconds for the timelapse duration
- clarify usage in README
- always render videos at 30 FPS

## Testing
- `python3 -m py_compile timelapse/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ca7d6005c832b81f62b48e2f73f36