### PR TITLE
Add hardware acceleration for video rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Dieses Repo richtet deinen Raspberry Pi Zero 2 W als WLAN-Hotspot ein, startet b
   - Download fertiger Videos
   - Aufnahme kann vorzeitig abgebrochen werden
 - **libcamera-still** für Bilder
- - **FFmpeg** für FHD-Videos (30 FPS)
+- **FFmpeg** für FHD-Videos (30 FPS)
+- Beschleunigte Videoerstellung über Hardware-Encoding (falls verfügbar)
 - **systemd**-Service für Autostart
 - Fortlaufend nummerierte Ordner und Videos
 


### PR DESCRIPTION
## Summary
- speed up video rendering using hardware-accelerated ffmpeg encoder when available
- log fallback to software encoder if hardware one fails
- mention hardware encoding in README

## Testing
- `python3 -m py_compile timelapse/app.py`


------
https://chatgpt.com/codex/tasks/task_e_684caba4ef5c832baff856e76095d1d8