### PR TITLE
Add RTC time settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Dieses Repo richtet deinen Raspberry Pi Zero 2 W als WLAN-Hotspot ein, startet b
   - Live-Vorschau (MJPEG)
   - Download fertiger Videos
   - Aufnahme kann vorzeitig abgebrochen werden
+  - Aktuelle Uhrzeit wird angezeigt
+  - Zeiteinstellung über DS3231 RTC
 - **libcamera-still** für Bilder
 - **FFmpeg** für FHD-Videos (30 FPS)
 - Beschleunigte Videoerstellung über Hardware-Encoding (falls verfügbar)
@@ -23,7 +25,7 @@ Dieses Repo richtet deinen Raspberry Pi Zero 2 W als WLAN-Hotspot ein, startet b
 - Raspberry Pi Zero 2 W mit Camera Module 3
 - Raspbian (aktuell)
 - Internetzugang einmalig zur Installation
-- Keine integrierte RTC – ohne Internet zeigt die Uhrzeit standardmäßig falsch an
+- DS3231 RTC-Unterstützung mit manueller Zeiteinstellung im Webinterface
 
 ## Installation
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,17 @@
 set -e
 
 # Install required packages
-sudo apt install -y hostapd dnsmasq python3-flask libcamera-apps ffmpeg authbind
+sudo apt install -y hostapd dnsmasq python3-flask libcamera-apps ffmpeg authbind \
+    i2c-tools python3-smbus
+
+# Configure DS3231 RTC
+sudo apt remove -y fake-hwclock
+sudo update-rc.d -f fake-hwclock remove
+sudo systemctl disable fake-hwclock
+sudo raspi-config nonint do_i2c 0
+if ! grep -q '^dtoverlay=i2c-rtc,ds3231' /boot/config.txt; then
+    echo 'dtoverlay=i2c-rtc,ds3231' | sudo tee -a /boot/config.txt
+fi
 
 # Copy network configuration files
 sudo cp network-config/dhcpcd.conf /etc/dhcpcd.conf

--- a/timelapse/templates/index.html
+++ b/timelapse/templates/index.html
@@ -20,6 +20,8 @@
 </head>
 <body>
   <h1>Timelapse-Konfiguration</h1>
+  <p>Aktuelle Zeit: {{ current_time }}</p>
+  <p><a href="{{ url_for('settings') }}">Einstellungen</a></p>
 
   {% if not capturing %}
   <div class="preview">

--- a/timelapse/templates/settings.html
+++ b/timelapse/templates/settings.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <title>Zeiteinstellungen</title>
+  <style>
+    body{font-family:sans-serif;background:#1a1a1a;color:#eee;margin:0;padding:1rem;}
+    h1{color:#f0a500;}
+    form{background:#2a2a2a;padding:1rem;border-radius:8px;box-shadow:0 2px 5px rgba(0,0,0,0.5);margin-bottom:1rem;}
+    label{display:block;margin:.5rem 0;}
+    input,button{padding:.4rem .6rem;border:none;border-radius:4px;margin-left:.5rem;}
+    button{background:#f0a500;color:#1a1a1a;cursor:pointer;font-weight:bold;}
+    a{color:#f0a500;text-decoration:none;}
+    a:hover{text-decoration:underline;}
+  </style>
+</head>
+<body>
+  <h1>Zeiteinstellungen</h1>
+  {% if message %}
+  <p>{{ message }}</p>
+  {% endif %}
+  <form method="post">
+    <label>Neue Zeit:
+      <input type="datetime-local" name="new_time" required>
+    </label>
+    <button type="submit">Zeit setzen</button>
+  </form>
+  <p>Aktuelle Systemzeit: {{ current_time }}</p>
+  <p><a href="{{ url_for('index') }}">Zurück</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enable DS3231 RTC support during install
- show current time on start page and link to new settings page
- allow setting system time and RTC via the web interface

## Testing
- `python3 -m py_compile timelapse/app.py`
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b8384c190832badf1ef0a9df9d3cf